### PR TITLE
fix: Disable eslint camelcase in wp.js

### DIFF
--- a/lib/wp.js
+++ b/lib/wp.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import axios from 'axios'
 import {
   WP_SITE_URL,


### PR DESCRIPTION
Fixes #4